### PR TITLE
Add Travis CI config for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+language: cpp
+os: windows
+
+git:
+  depth: 1
+
+before_install:
+# Set up MSYS2 and install required dependencies for building Curv
+# (copied and modified from https://docs.travis-ci.com/user/reference/windows/#how-do-i-use-msys2)
+- |-
+    case $TRAVIS_OS_NAME in
+      windows)
+        [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
+        choco uninstall -y mingw
+        choco upgrade --no-progress -y msys2
+        export msys2='cmd //C RefreshEnv.cmd '
+        export msys2+='& set MSYS=winsymlinks:nativestrict '
+        export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
+        export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
+        export msys2+=" -msys2 -c "\"\$@"\" --"
+        $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
+        ## Install more MSYS2 packages from https://packages.msys2.org/base here
+        $msys2 pacman --sync --noconfirm --needed diffutils mingw-w64-x86_64-clang make mingw-w64-x86_64-cmake git mingw-w64-x86_64-boost mingw-w64-x86_64-mesa mingw-w64-x86_64-openexr mingw-w64-x86_64-intel-tbb mingw-w64-x86_64-glm mingw-w64-x86_64-glew mingw-w64-x86_64-dbus patch doxygen
+        ## End: Install more MSYS2 packages
+        taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
+        export PATH=/C/tools/msys64/mingw64/bin:$PATH
+        # do NOT do this: export MAKE=mingw32-make  # so that Autotools can find it
+        # see https://stackoverflow.com/questions/51211360/internal-error-unable-to-open-jobserver-semaphore-3-4-error-2-the-syst for the reason
+        ;;
+    esac
+# Build and install OpenVDB package for MSYS2
+- |-
+    case $TRAVIS_OS_NAME in
+      windows)
+        git clone --depth=1 https://github.com/msys2/MINGW-packages.git
+        
+        pushd MINGW-packages/mingw-w64-openvdb
+        export MINGW_INSTALLS=mingw64
+        yes | $msys2 makepkg-mingw -sLf
+        $msys2 pacman --noconfirm --needed -U *.pkg.tar.zst
+        popd
+        ;;
+    esac
+before_cache:
+- |-
+    case $TRAVIS_OS_NAME in
+      windows)
+        # Update Msys
+        # https://unix.stackexchange.com/a/137322/107554
+        $msys2 pacman --sync --clean --noconfirm
+
+        # Update MINGW packages
+        # pushd MINGW-packages
+        # git pull
+        # popd
+        ;;
+    esac
+script:
+    - git submodule update --init
+    - $mingw64 make
+    - $mingw64 ./release/curv.exe -x 2+2
+    - $mingw64 ./release/curv.exe --help
+    - $mingw64 ./release/curv.exe --version
+cache:
+    directories:
+    - $HOME/AppData/Local/Temp/chocolatey
+    - /C/tools/msys64


### PR DESCRIPTION
It successfully produces `curv.exe`, see https://travis-ci.com/github/ComFreek/curv/builds/155448088#L1313-L1365 (never mind the "cancelled" message at the end - I cancelled it by accident.)

As of now it takes ~15-20min for the whole build. In particular, caching could be improved.

If CMakeLists.txt is improved to the point it can package all required DLLs, the Travis build could really be used to deploy *binary* Windows releases as GitHub release artifacts.

---

NB: I don't think it's useful to run the Travis build for Windows upon every pushed commit. It'd be a waste of resources. It could be configured such that it only runs on a specific branch, say, a `release` branch.