### PR TITLE
Windows build: use official openvdb package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,25 +20,12 @@ before_install:
         export msys2+=" -msys2 -c "\"\$@"\" --"
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
         ## Install more MSYS2 packages from https://packages.msys2.org/base here
-        $msys2 pacman --sync --noconfirm --needed diffutils mingw-w64-x86_64-clang make mingw-w64-x86_64-cmake git mingw-w64-x86_64-boost mingw-w64-x86_64-mesa mingw-w64-x86_64-openexr mingw-w64-x86_64-intel-tbb mingw-w64-x86_64-glm mingw-w64-x86_64-glew mingw-w64-x86_64-dbus patch doxygen
+        $msys2 pacman --sync --noconfirm --needed diffutils mingw-w64-x86_64-clang make mingw-w64-x86_64-cmake git mingw-w64-x86_64-boost mingw-w64-x86_64-mesa mingw-w64-x86_64-openexr mingw-w64-x86_64-intel-tbb mingw-w64-x86_64-glm mingw-w64-x86_64-glew mingw-w64-x86_64-dbus patch doxygen mingw-w64-x86_64-openvdb
         ## End: Install more MSYS2 packages
         taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
         export PATH=/C/tools/msys64/mingw64/bin:$PATH
         # do NOT do this: export MAKE=mingw32-make  # so that Autotools can find it
         # see https://stackoverflow.com/questions/51211360/internal-error-unable-to-open-jobserver-semaphore-3-4-error-2-the-syst for the reason
-        ;;
-    esac
-# Build and install OpenVDB package for MSYS2
-- |-
-    case $TRAVIS_OS_NAME in
-      windows)
-        git clone --depth=1 https://github.com/msys2/MINGW-packages.git
-        
-        pushd MINGW-packages/mingw-w64-openvdb
-        export MINGW_INSTALLS=mingw64
-        yes | $msys2 makepkg-mingw -sLf
-        $msys2 pacman --noconfirm --needed -U *.pkg.tar.zst
-        popd
         ;;
     esac
 before_cache:

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -52,27 +52,10 @@ then you will remove both MSYS2 and Curv.
  
  7. Install build tools and libraries:
     ```
-    pacman -S --needed diffutils mingw-w64-x86_64-clang make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-mesa mingw-w64-x86_64-openexr mingw-w64-x86_64-intel-tbb mingw-w64-x86_64-glm mingw-w64-x86_64-glew mingw-w64-x86_64-dbus patch
+    pacman -S --needed git diffutils mingw-w64-x86_64-clang make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-mesa mingw-w64-x86_64-openexr mingw-w64-x86_64-intel-tbb mingw-w64-x86_64-glm mingw-w64-x86_64-glew mingw-w64-x86_64-dbus patch mingw-w64-x86_64-openvdb
     ```
 
- 8. Download MINGW-packages:
-    ```
-    cd
-    git clone https://github.com/msys2/MINGW-packages
-    ```
-
- 9. Build openvdb:
-    ```
-    cd MINGW-packages/mingw-w64-openvdb
-    MINGW_INSTALLS=mingw64 makepkg-mingw -sLf
-    ```
-
-10. Install openvdb:
-    ```
-    pacman -U mingw-w64-x86_64-openvdb-*-any.pkg.tar.zst
-    ```
-
-11. Build curv:
+ 8. Build curv:
     ```
     cd
     cd curv
@@ -82,7 +65,7 @@ then you will remove both MSYS2 and Curv.
     The full pathname of this executable is:
     `C:\msys64\home\User\curv\release\curv.exe`.
 
-12. In order to run Curv from the Command Prompt or the PowerShell,
+ 9. In order to run Curv from the Command Prompt or the PowerShell,
     you need to add Curv to your PATH variable:
     * In the "Start search" box in the Windows 10 task bar,
       type "env" and hit ENTER.
@@ -94,7 +77,7 @@ then you will remove both MSYS2 and Curv.
       * `C:\msys64\mingw64\bin`
       * `C:\msys64\home\User\curv\release`
 
-13. In order to run Curv from the MSYS2 terminal window,
+10. In order to run Curv from the MSYS2 terminal window,
     you need to install `winpty`:
     ```
     pacman -S winpty


### PR DESCRIPTION
The openvdb package was previously unpublished, but now is published
and working (in fact the build as elaborated in #98 uses it as well).