### PR TITLE
multithreading export_mesh.cc and add a gcc flag in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ target_link_libraries(tester PUBLIC gtest pthread libcurv libcurv_geom double-co
 
 set_property(TARGET curv curvc libcurv libcurv_geom tester PROPERTY CXX_STANDARD 17)
 
-set(gccflags "-Wall -Wno-unused-result" )
+set(gccflags "-Wall -Wno-unused-result -fopenmp" )
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${gccflags}" )
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${gccflags}" )
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${sanitize} -O1" )

--- a/curv/export_mesh.cc
+++ b/curv/export_mesh.cc
@@ -16,6 +16,7 @@
 #include <libcurv/exception.h>
 #include <libcurv/context.h>
 #include <libcurv/die.h>
+#include <omp.h>
 
 using openvdb::Vec3s;
 using openvdb::Vec3d;
@@ -231,7 +232,7 @@ void export_mesh(Mesh_Format format, curv::Value value,
     // I assume each distance value is in the centre of a voxel.
     auto accessor = grid->getAccessor();
     if (cshape != nullptr) {
-        // TODO: use multiple threads, since cshape->dist is thread safe.
+        #pragma omp parallel for // uses multiple threads, since cshape->dist is thread safe.
         for (int x = voxelrange_min.x(); x <= voxelrange_max.x(); ++x) {
             for (int y = voxelrange_min.y(); y <= voxelrange_max.y(); ++y) {
                 for (int z = voxelrange_min.z(); z <= voxelrange_max.z(); ++z) {

--- a/curv/export_mesh.cc
+++ b/curv/export_mesh.cc
@@ -203,11 +203,13 @@ void export_mesh(Mesh_Format format, curv::Value value,
         int(ceil(shape.bbox_.ymax/voxelsize)) + 2,
         int(ceil(shape.bbox_.zmax/voxelsize)) + 2);
 
+    int vx = voxelrange_max.x() - voxelrange_min.x() + 1;
+    int vy = voxelrange_max.y() - voxelrange_min.y() + 1;
+    int vz = voxelrange_max.z() - voxelrange_min.z() + 1;
+
     std::cerr
-        << "vsize="<<voxelsize<<": "
-        << (voxelrange_max.x() - voxelrange_min.x() + 1) << "*"
-        << (voxelrange_max.y() - voxelrange_min.y() + 1) << "*"
-        << (voxelrange_max.z() - voxelrange_min.z() + 1)
+        << "vsize=" << voxelsize << ": "
+        << vx << "*"  << vy << "*" << vz
         << " voxels. Use '-O vsize=N' to change voxel size.\n";
     std::cerr.flush();
 
@@ -232,12 +234,25 @@ void export_mesh(Mesh_Format format, curv::Value value,
     // I assume each distance value is in the centre of a voxel.
     auto accessor = grid->getAccessor();
     if (cshape != nullptr) {
+        auto voxels = std::make_unique<float[]>(vx * vy *vz);
         #pragma omp parallel for // uses multiple threads, since cshape->dist is thread safe.
         for (int x = voxelrange_min.x(); x <= voxelrange_max.x(); ++x) {
             for (int y = voxelrange_min.y(); y <= voxelrange_max.y(); ++y) {
                 for (int z = voxelrange_min.z(); z <= voxelrange_max.z(); ++z) {
-                    accessor.setValue(openvdb::Coord{x,y,z},
-                        cshape->dist(x*voxelsize, y*voxelsize, z*voxelsize, 0.0));
+                    int i = (x - voxelrange_min.x()) * vy * vz
+                        + (y - voxelrange_min.y()) * vz
+                        + (z - voxelrange_min.z());
+                    voxels[i] = cshape->dist(x*voxelsize, y*voxelsize, z*voxelsize, 0.0);
+                }
+            }
+        }
+        for (int x = voxelrange_min.x(); x <= voxelrange_max.x(); ++x) {
+            for (int y = voxelrange_min.y(); y <= voxelrange_max.y(); ++y) {
+                for (int z = voxelrange_min.z(); z <= voxelrange_max.z(); ++z) {
+                    int i = (x - voxelrange_min.x()) * vy * vz
+                        + (y - voxelrange_min.y()) * vz
+                        + (z - voxelrange_min.z());
+                    accessor.setValue(openvdb::Coord{x,y,z}, voxels[i]);
                 }
             }
         }


### PR DESCRIPTION
I did exactly what you mentioned. Found this openmp tool to be very convenient and useful! I tried on my 4-core computer and the speed is really 3-4 times faster, with the utility of all the cores to be 100% when running. I don't see there's anything wrong about the output.

I will then test on my 16-core computer.