### PR TITLE
Add repeat finite

### DIFF
--- a/docs/lug.rst
+++ b/docs/lug.rst
@@ -219,7 +219,7 @@ Transformations
 * Non-affine: taper, twist, bend
 * 2D->3D: extrude, revolve
 * 3D->2D: slice
-* Repetition: repeat_x, repeat_xy, repeat_xyz, repeat_mirror, repeat_radial
+* Repetition: repeat_x, repeat_xy, repeat_xyz, repeat_finite, repeat_mirror, repeat_radial
 
 Additive/Subtractive Operations
 ===============================

--- a/docs/shapes/Repetition.rst
+++ b/docs/shapes/Repetition.rst
@@ -31,6 +31,12 @@ This interface is still experimental.
   This cell is repeated endlessly across 3D space.
   The shape must be 3D.
 
+``repeat_finite (dx,dy,dz) (lx,ly,lz) shape``
+  The original cell to be copied is a cuboid with dimensions (dx,dy,dz),
+  centred on the origin.
+  This cell is repeated as number of instances (lx,ly,lz) from origin.
+  The shape must be 3D.
+
 ``repeat_mirror_x shape``
   The contents of the positive X half-space
   are reflected through the YZ-plane

--- a/lib/curv/std.curv
+++ b/lib/curv/std.curv
@@ -1316,6 +1316,28 @@ repeat_xyz d shape =
         is_3d = shape.is_3d;
     };
 
+repeat_finite d l shape =
+    make_shape {
+        dist [x,y,z,t] =
+            shape.dist[
+                x - d@X*clamp[round(x/d@X), 0, l@X - 1],
+                y - d@Y*clamp[round(y/d@Y), 0, l@Y - 1],
+                z - d@Z*clamp[round(z/d@Z), 0, l@Z - 1],
+                t];
+        colour [x,y,z,t] =
+            shape.colour[
+                x - d@X*clamp[round(x/d@X), 0, l@X - 1],
+                y - d@Y*clamp[round(y/d@Y), 0, l@Y - 1],
+                z - d@Z*clamp[round(z/d@Z), 0, l@Z - 1],
+                t];
+        bbox = [
+            shape.bbox@MIN,
+            shape.bbox@MAX*l,
+        ];
+        is_2d = shape.is_2d;
+        is_3d = shape.is_3d;
+    };
+
 repeat_mirror_x shape =
     make_shape {
         dist[x,y,z,t] : shape.dist[abs x, y, z, t],


### PR DESCRIPTION
## Justification

> Infinite domain repetition is great, but sometimes you only need a few copies or instances of a given SDF, not infinite. A frequently seen but suboptimal solution is to generate infinite copies and then clip the unwanted areas away with a box SDF. This is not ideal because the resulting SDF is not a real SDF but just a bound, since clipping through max() only produces a bound. A much better approach is to clamp the indices of the instances instead of the SDF, and let a correct SDF emerge from the truncated/clamped indices. -IQ

See https://www.iquilezles.org/www/articles/distfunctions/distfunctions.htm. Section "Finite Repetition".

## Test
`box >> repeat_finite [3,3,3] [2.5,3,2]`, where [3,3,3] is the repeat period and [2.5,3,2] is number of instances. Note instance number < 1 is same as 1.

<img width="612" alt="Screen Shot 2021-04-25 at 7 09 58 PM" src="https://user-images.githubusercontent.com/2062827/116019804-e4437d00-a5f9-11eb-9a75-27b69cfb33d7.png">
