### PR TITLE
Fix repeat finite bbox max

### DIFF
--- a/lib/curv/std.curv
+++ b/lib/curv/std.curv
@@ -1332,7 +1332,7 @@ repeat_finite d l shape =
                 t];
         bbox = [
             shape.bbox@MIN,
-            shape.bbox@MAX*l,
+            shape.bbox@MIN + d*l,
         ];
         is_2d = shape.is_2d;
         is_3d = shape.is_3d;


### PR DESCRIPTION
Incorrect bbox max introduced in https://github.com/curv3d/curv/pull/121 😅

## How to test
```
box [1,2,2] >> repeat_finite [3,0,0] [12,0,0] >> bend {d:20}
```
Verify 12 boxes symetrically laid out.

<img width="438" alt="Screen Shot 2021-04-28 at 10 09 26 PM" src="https://user-images.githubusercontent.com/2062827/116504931-68059f80-a86e-11eb-9f2e-58f44ccc7b04.png">
