### PR TITLE
Add repeat_helix to curv std

### DIFF
--- a/docs/lug.rst
+++ b/docs/lug.rst
@@ -219,7 +219,7 @@ Transformations
 * Non-affine: taper, twist, bend
 * 2D->3D: extrude, revolve
 * 3D->2D: slice
-* Repetition: repeat_x, repeat_xy, repeat_xyz, repeat_finite, repeat_mirror, repeat_radial
+* Repetition: repeat_x, repeat_xy, repeat_xyz, repeat_finite, repeat_mirror, repeat_helix, repeat_radial
 
 Additive/Subtractive Operations
 ===============================

--- a/docs/shapes/Repetition.rst
+++ b/docs/shapes/Repetition.rst
@@ -49,6 +49,10 @@ This interface is still experimental.
   The contents of "slice 0" are copied into the other *n-1* slices.
   The shape may be 2D or 3D.
 
+``repeat_helix {reps:n, step:dz} shape``
+  Partition space into *n* radial pie slices, radiating from the Z axis while incrementing in Z+ by dz.
+  The shape must be 3D.
+
 Future Work
 -----------
 * Support more symmetries. For example, consider the `Wallpaper Symmetries`_, the `Frieze Symmetries`_,
@@ -57,7 +61,6 @@ Future Work
 * Permit the `shape` argument of each repetition operator to be optionally replaced by a function
   that maps a cell index onto a shape. This function can customize the contents of each cell or tile
   based on the cell index.
-* ``repeat_helix ... shape``
 
 .. _`Wallpaper Symmetries`: https://en.wikipedia.org/wiki/Wallpaper_group
 .. _`Frieze Symmetries`: https://en.wikipedia.org/wiki/Frieze_group

--- a/lib/curv/std.curv
+++ b/lib/curv/std.curv
@@ -1384,6 +1384,46 @@ repeat_radial reps shape =
         is_3d = shape.is_3d;
     };
 
+repeat_helix{reps, step} shape =
+    let angle = tau/reps;
+        inradius = -shape.bbox@MIN@Y;
+        circumradius = inradius / cos(angle/2);
+        max_x =
+            if (mod[reps,4]==0)
+                inradius
+            else if (mod[reps,2]==0)
+                circumradius
+            else
+                circumradius * sin((floor(reps/4)+.5)*angle);
+        ashift = tau/4 + angle/2;
+        f[x,y,z,t] =
+            let a = phase[x,y] + ashift;
+                r = mag[x,y];
+                i = clamp[round(z/step), 0, reps - 1];
+                a2 =
+                    if (step==0)
+                        mod[a,angle] - ashift
+                    else
+                        a - angle*mod[i,reps] - ashift;
+                xy = cis(a2) * r;
+                z2 = z - step*i;
+            in [xy@X, xy@Y, z2, t];
+    in make_shape {
+        dist p = shape.dist(f p);
+        colour p = shape.colour(f p);
+        // bbox is exact for regular_polygon, approximate for general case.
+        bbox = [
+            [ -max_x,
+              -inradius,
+              shape.bbox@MIN@Z ],
+            [ max_x,
+              if (mod[reps,2]==0) inradius else circumradius,
+              shape.bbox@MIN@Z + reps*step ]
+        ];
+        is_2d = shape.is_2d;
+        is_3d = shape.is_3d;
+    };
+
 ////////////
 // COLOUR //
 ////////////

--- a/libcurv/frag.cc
+++ b/libcurv/frag.cc
@@ -194,7 +194,7 @@ void export_frag_3d(
        "        float precis = 0.0005*t;\n"
        "        vec4 p = vec4(ro+rd*t,time);\n"
        "        float d = dist(p);\n"
-       "        if (d < precis) {\n"
+       "        if (abs(d) < precis) {\n"
        "            c = colour(p);\n"
        "            break;\n"
        "        }\n"


### PR DESCRIPTION
## Justification
`repeat_helix` was listed in the repetition future work section. It's useful for making staircases, chained links, etc. Also remapped `repeat_radial` as `repeat_helix` with step size of 0.

## How to test
```
parametric
    w :: slider[0, 20] = 15;
    dy :: slider[-20, 20] = 6;
    step :: slider[0, 40] = 5;
in
box [5,w,1]
    >> move [0,dy,0]
    >> repeat_helix{reps:12, step:step} 
    >> lipschitz 10
```

<img width="503" alt="Screen Shot 2021-05-01 at 9 02 44 AM" src="https://user-images.githubusercontent.com/2062827/116788644-a4e4b880-aa5f-11eb-824d-f8ca35da083b.png">
