### PR TITLE
Continue march backward when inside shape

### DIFF
--- a/libcurv/frag.cc
+++ b/libcurv/frag.cc
@@ -194,7 +194,7 @@ void export_frag_3d(
        "        float precis = 0.0005*t;\n"
        "        vec4 p = vec4(ro+rd*t,time);\n"
        "        float d = dist(p);\n"
-       "        if (abs(d) < precis) {\n"
+       "        if (abs(d) < abs(precis)) {\n"
        "            c = colour(p);\n"
        "            break;\n"
        "        }\n"

--- a/libcurv/frag.cc
+++ b/libcurv/frag.cc
@@ -194,7 +194,7 @@ void export_frag_3d(
        "        float precis = 0.0005*t;\n"
        "        vec4 p = vec4(ro+rd*t,time);\n"
        "        float d = dist(p);\n"
-       "        if (d < precis) {\n"
+       "        if (abs(d) < precis) {\n"
        "            c = colour(p);\n"
        "            break;\n"
        "        }\n"


### PR DESCRIPTION
## Justification
See previous comment on rendering artifacts in helix distance function: https://github.com/curv3d/curv/pull/124#issuecomment-830681165.

Here is a video I found by Martijn Steinrucken which explains the 2 scenarios where sphere tracer goes 1) inside shape 2) behind shape. https://www.youtube.com/watch?v=Vmb7VGBVZJA&t=505s

This PR fixes scenario 1 where tracer is inside shape. The fix is to keep the tracer loop going so it can take negative steps back and get closer to the isosurface.

Fix for scenario 2 is to reduce trace increments (`>> lipschitz x`).

## How to test
Here is a quick test on the helix repeat branch, but you can try any shape with render artifacts.
```
parametric
    w :: slider[0, 20] = 10;
    dy :: slider[-20, 20] = 10;
    step :: slider[0, 20] = 5;
in
box [3,w,3]
    >> move [0,dy,0]
    >> repeat_helix{reps:10, step:step} 
    >> lipschitz 1
```
Before:
<img width="612" alt="Screen Shot 2021-05-03 at 8 49 59 PM" src="https://user-images.githubusercontent.com/2062827/116960139-6401c500-ac54-11eb-9726-b5ea4d319654.png">
After:
<img width="612" alt="Screen Shot 2021-05-03 at 8 51 01 PM" src="https://user-images.githubusercontent.com/2062827/116960147-6bc16980-ac54-11eb-904d-3147dd662f18.png">
