### PR TITLE
Add 2D polyline

### DIFF
--- a/docs/lug.rst
+++ b/docs/lug.rst
@@ -204,8 +204,8 @@ Primitive Shapes
 ================
 2D:
 
-* circle, ellipse, stroke
-* square, rect, regular_polygon, convex_polygon, half_plane
+* circle, ellipse, stroke, polyline
+* square, rect, regular_polygon, polygon, half_plane
 
 3D:
 

--- a/docs/shapes/Shape_Constructors.rst
+++ b/docs/shapes/Shape_Constructors.rst
@@ -81,6 +81,13 @@ Shape Constructors
   with semicircle end caps of radius ``d/2``.
   Exact distance field.
 
+``polyline {d: diameter, v: vertices}``
+  A polyline of thickness ``d`` drawn with ``vertices``,
+  with semicircle end caps of radius ``d/2``.
+  Exact distance field.
+  Cost: linear in the number of vertices.
+  Exact distance field.
+
 ``half_plane ...``
   A half-plane is an infinite 2D shape consisting of all points on one side
   of an infinite straight line, and no points on the other side.

--- a/lib/curv/std.curv
+++ b/lib/curv/std.curv
@@ -265,6 +265,28 @@ stroke{d, from: a, to: b} =
         is_2d = true;
     };
 
+polyline{d, v} =
+    let r = d / 2;
+    in make_shape {
+        dist p =
+            do
+                local p = p@[X,Y];
+                local num = count v;
+                local d = dot[p-v@0, p-v@0];
+                local s = 1;
+                local j = 0;
+                for (i in 1..<num) (
+                    local e = v@j - v@i;
+                    local w = p - v@i;
+                    local b = w - e*clamp[dot[w,e]/dot[e,e], 0, 1];
+                    d := min[d, dot[b,b]];
+                    j := i;
+                );
+            in s * sqrt d - r;
+        bbox = [[...min v-r,0], [...max v+r,0]];
+        is_2d = true;
+    };
+
 // d1: major diameter, from center of tube, through origin, to centre of tube.
 // d2: minor diameter, of the tube.
 torus {major:d1, minor:d2} = perimeter_extrude (circle d1) (circle d2);


### PR DESCRIPTION
## Justification
I was trying to model a bridge truss and it was slow unioning a number of strokes. Polyline was derived from [IQ's polygon function](https://www.shadertoy.com/view/wdBXRW), sans the signed internal function and added stroke size (d).

## How to test
```
polyline {d:0.1, v:[[0,0],[1,0],[1,1],[0,0]]}  // right triangle
```
<img width="423" alt="Screen Shot 2021-05-06 at 8 23 21 PM" src="https://user-images.githubusercontent.com/2062827/117393394-eaaee000-aea8-11eb-9793-11929c10182d.png">

```
polyline {d:0.1, v:[[0,0],[1,0],[1,1],[0,0]]} >> extrude 0.2
```
<img width="423" alt="Screen Shot 2021-05-06 at 8 23 47 PM" src="https://user-images.githubusercontent.com/2062827/117393421-f9959280-aea8-11eb-8ac6-99c362418f4b.png">

