### PR TITLE
Added AppImage build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,3 +74,31 @@ jobs:
           release/*.exe
           release/*.dll
           lib
+
+  linux-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Set up dependencies
+      run: |
+        sudo apt install clang cmake git-core libboost-all-dev libopenexr-dev libtbb-dev libglm-dev dbus-x11
+        sudo apt install libxcursor-dev libxinerama-dev libxrandr-dev libgl-dev libxi-dev
+
+    - name: Build AppImage
+      run: |
+        sudo chmod +x build-appimage.sh
+        bash build-appimage.sh
+
+    - name: Test built executable
+      run: |
+        sudo chmod +x release/curv-x86_64.AppImage
+        ./release/curv-x86_64.AppImage --version
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: curv-appimage-${{ github.sha }}
+        path: release/curv-x86_64.AppImage

--- a/AppRun
+++ b/AppRun
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export PATH="$(dirname $0)/usr/bin:$PATH"
+
+curv $@

--- a/build-appimage.sh
+++ b/build-appimage.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# building in temporary directory to keep system clean
+# use RAM disk if possible (as in: not building on CI system like Travis, and RAM disk is available)
+if [ "$CI" == "" ] && [ -d /dev/shm ]; then
+    TEMP_BASE=/dev/shm
+else
+    TEMP_BASE=/tmp
+fi
+
+BUILD_DIR=$(mktemp -d -p "$TEMP_BASE" appimage-build-XXXXXX)
+
+# make sure to clean up build dir, even if errors occur
+cleanup () {
+    if [ -d "$BUILD_DIR" ]; then
+        rm -rf "$BUILD_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# store repo root as variable
+REPO_ROOT=$(readlink -f $(dirname $(dirname $0)))
+OLD_CWD=$(readlink -f .)
+
+# switch to build dir
+pushd "$BUILD_DIR"
+
+# configure build files with CMake
+# we need to explicitly set the install prefix, as CMake's default is /usr/local for some reason...
+cmake "$REPO_ROOT" -DCMAKE_INSTALL_PREFIX=/usr
+
+# build project and install files into AppDir
+make -j$(nproc)
+make install DESTDIR=AppDir
+
+# now, build AppImage using linuxdeploy and appimagetool
+# download linuxdeploy and appimagetool
+wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
+
+# make them executable
+chmod +x linuxdeploy*.AppImage
+chmod +x appimagetool-x86_64.AppImage
+
+# create desktop entry
+cat > curv.desktop << EOL
+[Desktop Entry]
+Name=curv
+GenericName=
+Exec=./AppRun %U
+Type=Application
+StartupNotify=true
+Path=
+Icon=curv
+StartupWMClass=curv
+Categories=Graphics
+Terminal=true
+Comment=Art creator app using mathematics
+EOL
+
+# patch absolute paths (make binary relocatable)
+sed -i -e 's#/usr#././#g' AppDir/usr/bin/curv
+
+# copy AppRun
+apprun_filename="$OLD_CWD/AppRun"
+chmod +x "$apprun_filename"
+cp "$apprun_filename" AppRun
+
+# configure the dummy X server
+if [[ -z "$DISPLAY" ]]; then
+  sudo apt update
+  sudo apt install xserver-xorg-video-dummy -y
+  dummy_xconf="dummy-1920x1080.conf"
+  cat > "$dummy_xconf" << EOL
+Section "Monitor"
+  Identifier "Monitor0"
+  HorizSync 28.0-80.0
+  VertRefresh 48.0-75.0
+  # https://arachnoid.com/modelines/
+  # 1920x1080 @ 60.00 Hz (GTF) hsync: 67.08 kHz; pclk: 172.80 MHz
+  Modeline "1920x1080_60.00" 172.80 1920 2040 2248 2576 1080 1081 1084 1118 -HSync +Vsync
+EndSection
+Section "Device"
+  Identifier "Card0"
+  Driver "dummy"
+  VideoRam 256000
+EndSection
+Section "Screen"
+  DefaultDepth 24
+  Identifier "Screen0"
+  Device "Card0"
+  Monitor "Monitor0"
+  SubSection "Display"
+    Depth 24
+    Modes "1920x1080_60.00"
+  EndSubSection
+EndSection
+EOL
+  sudo X -config "$dummy_xconf" &
+  export DISPLAY=:0
+  sleep 1
+fi
+
+# create curv's icon using curv
+icon_filename="curv.png"
+./AppDir/usr/bin/curv -o "$icon_filename" -O xsize=512 -O ysize=512 "$OLD_CWD/icon.curv"
+
+# kill dummy X server
+if [[ ! -z "$dummy_conf" ]]; then
+  sudo kill $(pgrep X)
+  rm "$dummy_xconf"
+fi
+
+# bundle shared libraries for Curv to AppDir, and build AppImage
+./linuxdeploy-x86_64.AppImage --appdir AppDir -d curv.desktop -i "$icon_filename" --custom-apprun AppRun
+./appimagetool-x86_64.AppImage AppDir
+
+# move built AppImage into release folder
+mkdir -p "$OLD_CWD/release"
+mv curv*.AppImage "$OLD_CWD/release"

--- a/build-appimage.sh
+++ b/build-appimage.sh
@@ -3,78 +3,41 @@
 set -x
 set -e
 
-# building in temporary directory to keep system clean
-# use RAM disk if possible (as in: not building on CI system like Travis, and RAM disk is available)
-if [ "$CI" == "" ] && [ -d /dev/shm ]; then
-    TEMP_BASE=/dev/shm
-else
-    TEMP_BASE=/tmp
-fi
-
-BUILD_DIR=$(mktemp -d -p "$TEMP_BASE" appimage-build-XXXXXX)
-
-# make sure to clean up build dir, even if errors occur
+# do cleanup, even if errors occur
 cleanup () {
-    if [ -d "$BUILD_DIR" ]; then
-        rm -rf "$BUILD_DIR"
-    fi
+  # remove temp downloaded files and AppImage-build artifacts
+  rm -f linuxdeploy-x86_64.AppImage
+  rm -f appimagetool-x86_64.AppImage
+  rm -f $desktop_filename
+  rm -f $icon_filename
 }
 trap cleanup EXIT
 
 # store repo root as variable
-REPO_ROOT=$(readlink -f $(dirname $(dirname $0)))
-OLD_CWD=$(readlink -f .)
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+BUILD_DIR=release
+APPDIR=$BUILD_DIR/AppDir
 
-# switch to build dir
-pushd "$BUILD_DIR"
+cd "$REPO_ROOT"
 
-# configure build files with CMake
-# we need to explicitly set the install prefix, as CMake's default is /usr/local for some reason...
-cmake "$REPO_ROOT" -DCMAKE_INSTALL_PREFIX=/usr
-
-# build project and install files into AppDir
+# build project and install files into AppDir/usr
 make -j$(nproc)
 make install DESTDIR=AppDir
 
-# now, build AppImage using linuxdeploy and appimagetool
-# download linuxdeploy and appimagetool
-wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
-
-# make them executable
-chmod +x linuxdeploy*.AppImage
-chmod +x appimagetool-x86_64.AppImage
-
-# create desktop entry
-cat > curv.desktop << EOL
-[Desktop Entry]
-Name=curv
-GenericName=
-Exec=./AppRun %U
-Type=Application
-StartupNotify=true
-Path=
-Icon=curv
-StartupWMClass=curv
-Categories=Graphics
-Terminal=true
-Comment=Art creator app using mathematics
-EOL
+# rename usr/local -> usr/
+cd $APPDIR/usr/local && mv * .. && cd .. && rmdir local
+cd "$REPO_ROOT"
 
 # patch absolute paths (make binary relocatable)
-sed -i -e 's#/usr#././#g' AppDir/usr/bin/curv
-
-# copy AppRun
-apprun_filename="$OLD_CWD/AppRun"
-chmod +x "$apprun_filename"
-cp "$apprun_filename" AppRun
+sed -i -e 's#/usr#././#g' $APPDIR/usr/bin/curv
 
 # configure the dummy X server
 if [[ -z "$DISPLAY" ]]; then
   sudo apt update
   sudo apt install xserver-xorg-video-dummy -y
-  dummy_xconf="dummy-1920x1080.conf"
-  cat > "$dummy_xconf" << EOL
+
+  dummy_xconf=dummy-1920x1080.conf
+  cat > $dummy_xconf << EOL
 Section "Monitor"
   Identifier "Monitor0"
   HorizSync 28.0-80.0
@@ -99,25 +62,54 @@ Section "Screen"
   EndSubSection
 EndSection
 EOL
-  sudo X -config "$dummy_xconf" &
+  sudo X -config $dummy_xconf &
   export DISPLAY=:0
   sleep 1
 fi
 
-# create curv's icon using curv
-icon_filename="curv.png"
-./AppDir/usr/bin/curv -o "$icon_filename" -O xsize=512 -O ysize=512 "$OLD_CWD/icon.curv"
+# create AppImage's icon using curv
+icon_filename=$BUILD_DIR/curv.png
+./$APPDIR/usr/bin/curv -o $icon_filename -O xsize=512 -O ysize=512 icon.curv
 
 # kill dummy X server
-if [[ ! -z "$dummy_conf" ]]; then
+if [[ ! -z $dummy_xconf ]]; then
   sudo kill $(pgrep X)
-  rm "$dummy_xconf"
+  rm $dummy_xconf
 fi
 
-# bundle shared libraries for Curv to AppDir, and build AppImage
-./linuxdeploy-x86_64.AppImage --appdir AppDir -d curv.desktop -i "$icon_filename" --custom-apprun AppRun
-./appimagetool-x86_64.AppImage AppDir
+# create desktop entry for AppImage
+desktop_filename=$BUILD_DIR/curv.desktop
+cat > $desktop_filename << EOL
+[Desktop Entry]
+Name=curv
+GenericName=
+Exec=./AppRun %U
+Type=Application
+StartupNotify=true
+Path=
+Icon=curv
+StartupWMClass=curv
+Categories=Graphics
+Terminal=true
+Comment=Art creator app using mathematics
+EOL
+
+# now, build AppImage using linuxdeploy and appimagetool
+# download linuxdeploy and appimagetool
+wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
+
+# make them executable
+chmod +x linuxdeploy-x86_64.AppImage
+chmod +x appimagetool-x86_64.AppImage
+
+# bundle shared libraries for curv to AppDir, and build AppImage from AppDir
+./linuxdeploy-x86_64.AppImage \
+  --appdir $APPDIR \
+  --custom-apprun AppRun \
+  -d $desktop_filename \
+  -i $icon_filename
+./appimagetool-x86_64.AppImage $APPDIR
 
 # move built AppImage into release folder
-mkdir -p "$OLD_CWD/release"
-mv curv*.AppImage "$OLD_CWD/release"
+mv curv*.AppImage $BUILD_DIR

--- a/icon.curv
+++ b/icon.curv
@@ -1,0 +1,23 @@
+let
+SHAPE_TWISTS = 1/3;
+SHAPE_LENGTH = 16;
+CSECTION_RATIO = [1, sqrt(3), SHAPE_LENGTH];
+BEND_ANGLE = (3/4)*tau;
+FINAL_SCALE_FACTOR = [0.9, 1, 1];
+HUE = make_texture([x, y, z, t]->sRGB.hue((SHAPE_TWISTS/SHAPE_LENGTH)*x + sin(y*z)*cos(y*z)));
+
+in
+let shape = ellipsoid CSECTION_RATIO
+    >> twist (SHAPE_TWISTS*pi/SHAPE_LENGTH)
+    >> rotate {angle: pi/2, axis: [0, 1, 0]}
+    >> colour HUE
+    >> bend {angle: BEND_ANGLE}
+    >> rotate {angle: -pi/2, axis: [0, 0, 1]}
+    >> stretch FINAL_SCALE_FACTOR
+
+// Prepare shape view for export
+in
+shape
+    >> set_bbox [shape.bbox.[MIN] + [2, 2.2, 0], shape.bbox.[MAX] - [3, 2.2, 0]]
+    >> rotate {angle: 60*deg, axis: [1, 0, 0]}
+    >> rotate {angle: 30*deg, axis: [0, 0, 1]}


### PR DESCRIPTION
- Added:
  - `linux-build` action to github actions
  - `build-appimage.sh` - AppImage builder script
  - `AppRun` - Entry point for AppImage execution (required by AppImage spec)
  - `icon.curv` - will be exported to png (icon required by AppImage spec)