### PR TITLE
Expose window size and update icon to be thicker

### DIFF
--- a/icon.curv
+++ b/icon.curv
@@ -2,13 +2,14 @@ let
 SHAPE_TWISTS = 1/3;
 SHAPE_LENGTH = 16;
 CSECTION_RATIO = [1, sqrt(3), SHAPE_LENGTH];
-BEND_ANGLE = (3/4)*tau;
+BEND_ANGLE = (7/8)*tau;
 FINAL_SCALE_FACTOR = [0.9, 1, 1];
 HUE = make_texture([x, y, z, t]->sRGB.hue((SHAPE_TWISTS/SHAPE_LENGTH)*x + sin(y*z)*cos(y*z)));
 
 in
 let shape = ellipsoid CSECTION_RATIO
     >> twist (SHAPE_TWISTS*pi/SHAPE_LENGTH)
+    >> stretch [1, 2, 1]
     >> rotate {angle: pi/2, axis: [0, 1, 0]}
     >> colour HUE
     >> bend {angle: BEND_ANGLE}

--- a/libcurv/builtin.cc
+++ b/libcurv/builtin.cc
@@ -1501,6 +1501,18 @@ struct Builtin_Time : public Builtin
     }
 };
 
+struct Builtin_Resolution : public Builtin
+{
+    virtual Shared<Meaning> to_meaning(const Identifier& id) const
+    {
+        return make<Constant>(share(id), Value{make<Uniform_Variable>(
+            make_symbol("resolution"),
+            std::string("u_resolution"),
+            SC_Type::List(SC_Type::Num(), 2),
+            share(id))});
+    }
+};
+
 const Namespace&
 builtin_namespace()
 {
@@ -1514,6 +1526,7 @@ builtin_namespace()
     {make_symbol("false"), make<Builtin_Value>(Value(false))},
     {make_symbol("true"), make<Builtin_Value>(Value(true))},
     {make_symbol("time"), make<Builtin_Time>()},
+    {make_symbol("resolution"), make<Builtin_Resolution>()},
 
     FUNCTION("is_bool", Is_Bool_Function),
     FUNCTION("is_char", Is_Char_Function),


### PR DESCRIPTION
(fork name is incorrect: it's already exposed as a uniform in the GLSL code. It needs to be exposed to the Curv language).

Useful for cases which rely on knowing where a point is relative to the view.

---

Also includes the icon changes. If you really want me to split into two PR let me know...